### PR TITLE
Add sonarJavaCertificate for LDAPS communication

### DIFF
--- a/stable/sonarqube/templates/startup-config.yaml
+++ b/stable/sonarqube/templates/startup-config.yaml
@@ -14,4 +14,10 @@ data:
     if [ -e /tmp/conf/sonar.properties ]; then
       cp /tmp/conf/sonar.properties /opt/sonarqube/conf/sonar.properties
     fi
+    {{- if .Values.sonarJavaCertificate }}
+    cat > certificate.cer <<- EOL
+{{ .Values.sonarJavaCertificate | indent 4 }}
+    EOL
+    keytool -importcert -file certificate.cer -keystore $JAVA_HOME/jre/lib/security/cacerts -alias "ldap-tls" -storepass changeit -noprompt
+    {{- end}}
     /opt/sonarqube/bin/run.sh

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -92,6 +92,12 @@ plugins:
 #   sonar.security.realm=LDAP
 #   ldap.url=ldaps://organization.com
 
+# A certificate for java keystore, can be provided using a multiline YAML string.
+# For example:
+# sonarJavaCertificate: |
+#   -----BEGIN CERTIFICATE-----
+#   -----END CERTIFICATE-----
+
 ## Configuration values for the postgresql dependency
 ## ref: https://github.com/kubernetes/charts/blob/master/stable/postgresql/README.md
 ##


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
With this fix we can add a certificate to java keystore and use it with LDAP plugins and ldaps setup

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
